### PR TITLE
RDKB-61080: XLE LTE Cell Info telemetry implementation

### DIFF
--- a/source/CellularManager/cellular_hal.c
+++ b/source/CellularManager/cellular_hal.c
@@ -577,3 +577,13 @@ int cellular_hal_modem_reset( void )
 
     return RETURN_OK;
 }
+
+int cellular_hal_get_cell_info(CellularCellInfo *cell_info, unsigned int *total_cell_count) 
+{
+#ifdef QMI_SUPPORT
+    // Get intra, inter frequency cell information
+    return cellular_hal_qmi_get_cell_information(cell_info, total_cell_count);
+#else
+    return RETURN_OK;
+#endif
+}

--- a/source/CellularManager/cellular_hal.h
+++ b/source/CellularManager/cellular_hal.h
@@ -349,6 +349,26 @@ typedef  struct
 
 } CellularNetworkScanResultInfoStruct;
 
+typedef struct
+{
+    unsigned int                            MCC;
+    unsigned int                            MNC;
+    unsigned int                            TAC;
+    unsigned int                            globalCellId;
+    char                                    RAT[BUFLEN_128];
+    int                                     RSSI;
+    int                                     RSRP;
+    int                                     RSRQ;
+    unsigned int                            TA;
+    unsigned int                            physicalCellId;
+    unsigned int                            RFCN;
+    unsigned int                            sectorId;
+    bool                                    isServing;
+    char                                    GPS[BUFLEN_128];
+    char                                    scanType[BUFLEN_128];
+    char                                    operatorName[BUFLEN_32];
+} CellularCellInfo;
+
 /* Cellular Device Status Events and Callbacks */
 
 /** Cellular Device Detection Status */

--- a/source/CellularManager/cellular_hal_qmi_apis.h
+++ b/source/CellularManager/cellular_hal_qmi_apis.h
@@ -20,6 +20,8 @@
 #ifndef _CELLULAR_HAL_QMI_APIS_H_
 #define _CELLULAR_HAL_QMI_APIS_H_
 
+#define  CELLULAR_QMI_INTER_FREQ_MAX_CNT    ( 20 ) 
+
 #include "cellular_hal_utils.h"
 
 /**********************************************************************
@@ -97,4 +99,5 @@ int cellular_hal_qmi_get_supported_radio_technology(char *supported_rat);
 int cellular_hal_qmi_get_preferred_radio_technology( char *preferred_rat);
 int cellular_hal_qmi_set_preferred_radio_technology( char *preferred_rat);
 int cellular_hal_qmi_get_current_radio_technology( char *current_rat);
+int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned int *pTotal_cell_count);
 #endif //_CELLULAR_HAL_QMI_APIS_H_

--- a/source/CellularManager/cellularmgr_cellular_apis.h
+++ b/source/CellularManager/cellularmgr_cellular_apis.h
@@ -38,9 +38,10 @@
 */
 
 /* Accesspoint list should be populated for below TTL interval */
-#define CELLULAR_ACCESSPOINT_LIST_REFRESH_THRESHOLD      (120)
-#define CELLULAR_UICCSLOT_LIST_REFRESH_THRESHOLD         (30)
-#define CELLULAR_AVAILABLE_NETWORK_LIST_REFRESH_THRESHOLD (60)
+#define CELLULAR_ACCESSPOINT_LIST_REFRESH_THRESHOLD         (120)
+#define CELLULAR_UICCSLOT_LIST_REFRESH_THRESHOLD            (30)
+#define CELLULAR_AVAILABLE_NETWORK_LIST_REFRESH_THRESHOLD   (60)
+#define CELLULAR_INTERFACE_CELLINFO_LIST_REFRESH_THRESHOLD  (120)
 
 #define CELLULAR_RADIO_ENV_EXCELLENT_THRESHOLD           (-85)
 #define CELLULAR_RADIO_ENV_GOOD_THRESHOLD_HIGH           (-85)
@@ -71,6 +72,8 @@
 #define PARTNERS_DEFAULTS_CELLULARMANAGER_DEFAULT_PROFILE_PASSWORD         "Device.Cellular.AccessPoint.X_RDK_DefaultAPN.1.Password"
 #define PARTNERS_DEFAULTS_CELLULARMANAGER_DEFAULT_PROFILE_IS_NOROAMING     "Device.Cellular.AccessPoint.X_RDK_DefaultAPN.1.IsNoRoaming"
 #define PARTNERS_DEFAULTS_CELLULARMANAGER_DEFAULT_PROFILE_IS_APNDISABLED   "Device.Cellular.AccessPoint.X_RDK_DefaultAPN.1.IsAPNDisabled"
+
+#define  CELLULAR_INTRA_INTER_FREQ_MAX_CNT               (20)
 
 extern char MCCMNC[10];
 
@@ -358,6 +361,28 @@ _CELLULAR_PLMNACCESS_INFO
 }
 CELLULAR_PLMNACCESS_INFO,  *PCELLULAR_PLMNACCESS_INFO;
 
+typedef struct
+_CELLULAR_INTERFACE_CELL_INFO
+{
+   UINT                                MCC;
+   UINT                                MNC;
+   UINT                                TAC;
+   UINT                                GlobalCellId;
+   CHAR                                RAT[128];
+   INT                                 RSSI;
+   INT                                 RSRP;
+   INT                                 RSRQ;
+   UINT                                TA;
+   UINT                                PhysicalCellId;
+   UINT                                RFCN;
+   UINT                                SectorId;
+   BOOLEAN                             IsServing;
+   CHAR                                GPS[128];
+   CHAR                                ScanType[128];
+   CHAR                                OperatorName[128];
+}
+CELLULAR_INTERFACE_CELL_INFO, *PCELLULAR_INTERFACE_CELL_INFO;
+
 typedef  struct
 _CELLULAR_INTERFACE_INFO                                         
 {
@@ -391,6 +416,9 @@ _CELLULAR_INTERFACE_INFO
     UINT                                        Global_cell_id;
     UINT                                        BandInfo;
     UINT                                        Serving_cell_id;
+    ULONG                                       ulCellInfoListLastUpdatedTime;
+    UINT                                        ulCellInfoNoOfEntries;
+    PCELLULAR_INTERFACE_CELL_INFO               pstCellInfo;
 }
 CELLULAR_INTERFACE_INFO,  *PCELLULAR_INTERFACE_INFO;
 
@@ -535,6 +563,8 @@ int rbus_get_int32(char * path, int* value);
 void CellularMgr_NetworkPacketStatisticsInit(void);
 
 int CellularMgr_NetworkPacketStatisticsUpdate(PCELLULAR_INTERFACE_STATS_INFO pstStatsInfo);
+
+int CellularMgr_GetCellInformation( PCELLULAR_INTERFACE_CELL_INFO *ppstCellInfo, unsigned int *puiTotalCount, CELL_LOCATION_SUBINFO loc );
 
 #ifdef RDK_SPEEDTEST_LTE
 void CellularMgr_EnableSpeedTest( bool bEnable );

--- a/source/TR-181/middle_layer_src/cellularmgr_cellular_dml.c
+++ b/source/TR-181/middle_layer_src/cellularmgr_cellular_dml.c
@@ -5003,6 +5003,443 @@ Cellular_AccessPoint_Rollback
     return ANSC_STATUS_SUCCESS;
 }
 
+/***********************************************************************
+
+ APIs for Object:
+
+    Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.
+
+    *  Cellular_Interface_CellInfo_IsUpdated
+    *  Cellular_Interface_CellInfo_Synchronize
+    *  Cellular_Interface_CellInfo_GetEntryCount
+    *  Cellular_Interface_CellInfo_GetEntry
+    *  Cellular_Interface_CellInfo_GetParamUlongValue
+    *  Cellular_Interface_CellInfo_GetParamStringValue
+    *  Cellular_Interface_CellInfo_GetParamIntValue
+    *  Cellular_Interface_CellInfo_GetParamBoolValue
+
+***********************************************************************/
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        Cellular_Interface_CellInfo_IsUpdated
+            (
+                ANSC_HANDLE                 hInsContext
+            );
+
+    description:
+
+        This function is checking whether the table is updated or not.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+    return:     TRUE or FALSE.
+
+**********************************************************************/
+BOOL
+Cellular_Interface_CellInfo_IsUpdated
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{
+    return TRUE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        ULONG
+        Cellular_Interface_CellInfo_Synchronize
+            (
+                ANSC_HANDLE                 hInsContext
+            );
+
+    description:
+
+        This function is called to synchronize the table.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+    return:     The status of the operation.
+
+**********************************************************************/
+ULONG
+Cellular_Interface_CellInfo_Synchronize
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{   
+    PCELLULAR_INTERFACE_INFO                   pstInterfaceInfo = (PCELLULAR_INTERFACE_INFO)hInsContext;
+    int i;
+
+    //Get available intra, inter frequency cell information
+    CELL_LOCATION_SUBINFO loc = CellularMgr_GetCellLocationSubsciptionStatus( );
+    CellularMgr_GetCellInformation(&pstInterfaceInfo->pstCellInfo, &pstInterfaceInfo->ulCellInfoNoOfEntries, loc);
+
+    return ANSC_STATUS_SUCCESS;
+}
+
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        ULONG
+        Cellular_Interface_CellInfo_GetEntryCount
+            (
+                ANSC_HANDLE                 hInsContext
+            );
+
+    description:
+
+        This function is called to retrieve the count of the table.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+    return:     The count of the table
+
+**********************************************************************/
+ULONG
+Cellular_Interface_CellInfo_GetEntryCount
+    (
+        ANSC_HANDLE                 hInsContext
+    )
+{   
+    PCELLULAR_INTERFACE_INFO    pstInterfaceInfo = (PCELLULAR_INTERFACE_INFO)hInsContext;
+
+    return pstInterfaceInfo->ulCellInfoNoOfEntries;
+}
+
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        ANSC_HANDLE
+        Cellular_Interface_CellInfo_GetEntry
+            (
+                ANSC_HANDLE                 hInsContext,
+                ULONG                       nIndex,
+                ULONG*                      pInsNumber
+            );
+
+    description:
+
+        This function is called to retrieve the entry specified by the index.
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                ULONG                       nIndex,
+                The index of this entry;
+
+                ULONG*                      pInsNumber
+                The output instance number;
+
+    return:     The handle to identify the entry
+
+**********************************************************************/
+ANSC_HANDLE
+Cellular_Interface_CellInfo_GetEntry
+    (
+        ANSC_HANDLE                 hInsContext,
+        ULONG                       nIndex,
+        ULONG*                      pInsNumber
+    )
+{    
+    PCELLULAR_INTERFACE_INFO                   pstInterfaceInfo = (PCELLULAR_INTERFACE_INFO)hInsContext;
+    PCELLULAR_INTERFACE_CELL_INFO              pstCellInfo = &(pstInterfaceInfo->pstCellInfo[nIndex]);
+
+    *pInsNumber = nIndex + 1;
+
+    return (pstCellInfo); /* return the handle */
+}
+
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        Cellular_Interface_CellInfo_GetParamStringValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                char*                       pString
+            );
+
+    description:
+
+        This function is called to set string parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                char*                       pString
+                The updated string value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+BOOL
+Cellular_Interface_CellInfo_GetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pString
+    )
+{
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)hInsContext;
+
+    /* check the parameter name and return the corresponding value */
+    if( AnscEqualString(ParamName, "RAT", TRUE))   
+    {
+        /* save update to backup */
+        AnscCopyString(pstCellInfo->RAT, pString);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "GPS", TRUE) )
+    {
+        /* save update to backup */
+        AnscCopyString(pstCellInfo->GPS, pString);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "ScanType", TRUE) )
+    {
+        /* save update to backup */
+        AnscCopyString(pstCellInfo->ScanType, pString);
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "OperatorName", TRUE) )
+    {
+        /* save update to backup */
+        AnscCopyString(pstCellInfo->OperatorName, pString);
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************  
+
+    caller:     owner of this object 
+
+    prototype: 
+
+        BOOL
+        Cellular_Interface_CellInfo_GetParamUlongValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                ULONG*                      puLong
+            );
+
+    description:
+
+        This function is called to retrieve ULONG parameter value; 
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                ULONG*                      puLong
+                The buffer of returned ULONG value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+BOOL
+Cellular_Interface_CellInfo_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      puLong
+    )
+{    
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)hInsContext;
+
+    /* check the parameter name and return the corresponding value */
+    if( AnscEqualString(ParamName, "MCC", TRUE))   
+    {
+        *puLong = pstCellInfo->MCC;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "MNC", TRUE))   
+    {
+        *puLong = pstCellInfo->MNC;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "TAC", TRUE))   
+    {
+        *puLong = pstCellInfo->TAC;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "GlobalCellId", TRUE))   
+    {
+        *puLong = pstCellInfo->GlobalCellId;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "TA", TRUE))   
+    {
+        *puLong = pstCellInfo->TA;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "PhysicalCellId", TRUE))   
+    {
+        *puLong = pstCellInfo->PhysicalCellId;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "RFCN", TRUE))   
+    {
+        *puLong = pstCellInfo->RFCN;    
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "SectorId", TRUE))   
+    {
+        *puLong = pstCellInfo->SectorId;    
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************
+
+    caller:     owner of this object
+
+    prototype:
+
+        BOOL
+        Cellular_Interface_CellInfo_GetParamIntValue
+            (   
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                int*                        pInt
+            );
+
+    description:
+
+        This function is called to retrieve integer parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                int*                        pInt
+                The buffer of returned integer value;
+
+    return:     TRUE if succeeded.
+
+**********************************************************************/
+
+BOOL
+Cellular_Interface_CellInfo_GetParamIntValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        int*                        pInt
+    )
+{
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)hInsContext;
+
+    /* check the parameter name and return the corresponding value */
+    if( AnscEqualString(ParamName, "RSSI", TRUE))
+    {
+        *pInt = pstCellInfo->RSSI;
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "RSRP", TRUE))
+    {
+        *pInt = pstCellInfo->RSRP;
+        return TRUE;
+    }
+
+    if( AnscEqualString(ParamName, "RSRQ", TRUE))
+    {
+        *pInt = pstCellInfo->RSRQ;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/**********************************************************************
+    caller:     owner of this object
+
+    prototype:
+        BOOL
+        Cellular_Interface_CellInfo_GetParamBoolValue
+            (
+                ANSC_HANDLE                 hInsContext,
+                char*                       ParamName,
+                BOOL*                       pBool
+            );
+
+    description:
+        This function is called to retrieve Boolean parameter value;
+
+    argument:   ANSC_HANDLE                 hInsContext,
+                The instance handle;
+
+                char*                       ParamName,
+                The parameter name;
+
+                BOOL*                       pBool
+                The buffer of returned boolean value;
+
+    return:     TRUE if succeeded.
+**********************************************************************/
+BOOL
+Cellular_Interface_CellInfo_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    )
+{
+    PCELLULAR_INTERFACE_CELL_INFO  pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)hInsContext;
+
+    /* check the parameter name and return the corresponding value */
+    if( AnscEqualString(ParamName, "IsServing", TRUE) )
+    {
+        *pBool = pstCellInfo->IsServing;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 #ifdef RDK_SPEEDTEST_LTE
 /***********************************************************************
 

--- a/source/TR-181/middle_layer_src/cellularmgr_cellular_dml.h
+++ b/source/TR-181/middle_layer_src/cellularmgr_cellular_dml.h
@@ -891,6 +891,81 @@ Cellular_AccessPoint_Rollback
         ANSC_HANDLE                 hInsContext
     );
 
+/***********************************************************************
+
+ APIs for Object:
+
+    Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.
+
+    *  Cellular_Interface_CellInfo_IsUpdated
+    *  Cellular_Interface_CellInfo_Synchronize
+    *  Cellular_Interface_CellInfo_GetEntryCount
+    *  Cellular_Interface_CellInfo_GetEntry
+    *  Cellular_Interface_CellInfo_GetParamUlongValue
+    *  Cellular_Interface_CellInfo_GetParamStringValue
+    *  Cellular_Interface_CellInfo_GetParamIntValue
+    *  Cellular_Interface_CellInfo_GetParamBoolValue
+
+***********************************************************************/
+
+BOOL
+Cellular_Interface_CellInfo_IsUpdated
+    (
+        ANSC_HANDLE                 hInsContext
+    );
+
+ULONG
+Cellular_Interface_CellInfo_Synchronize
+    (
+        ANSC_HANDLE                 hInsContext
+    );
+
+ULONG
+Cellular_Interface_CellInfo_GetEntryCount
+    (
+        ANSC_HANDLE                 hInsContext
+    );
+
+ANSC_HANDLE
+Cellular_Interface_CellInfo_GetEntry
+    (
+        ANSC_HANDLE                 hInsContext,
+        ULONG                       nIndex,
+        ULONG*                      pInsNumber
+    );
+
+BOOL
+Cellular_Interface_CellInfo_GetParamUlongValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        ULONG*                      puLong
+    );
+
+BOOL
+Cellular_Interface_CellInfo_GetParamStringValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        char*                       pString
+    );
+
+BOOL
+Cellular_Interface_CellInfo_GetParamIntValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        int*                        pInt
+    );
+
+BOOL
+Cellular_Interface_CellInfo_GetParamBoolValue
+    (
+        ANSC_HANDLE                 hInsContext,
+        char*                       ParamName,
+        BOOL*                       pBool
+    );
+
 #ifdef RDK_SPEEDTEST_LTE
 /***********************************************************************
 

--- a/source/TR-181/middle_layer_src/cellularmgr_plugin_main.c
+++ b/source/TR-181/middle_layer_src/cellularmgr_plugin_main.c
@@ -211,6 +211,15 @@ int ANSC_EXPORT_API CellularMgr_DMLInit
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_AccessPoint_Validate",  Cellular_AccessPoint_Validate);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_AccessPoint_Commit",  Cellular_AccessPoint_Commit);
     pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_AccessPoint_Rollback",  Cellular_AccessPoint_Rollback);
+
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetEntryCount",  Cellular_Interface_CellInfo_GetEntryCount);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetEntry",  Cellular_Interface_CellInfo_GetEntry);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_IsUpdated",  Cellular_Interface_CellInfo_IsUpdated);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_Synchronize",  Cellular_Interface_CellInfo_Synchronize);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetParamUlongValue",  Cellular_Interface_CellInfo_GetParamUlongValue);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetParamStringValue",  Cellular_Interface_CellInfo_GetParamStringValue);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetParamIntValue",  Cellular_Interface_CellInfo_GetParamIntValue);
+    pPlugInfo->RegisterFunction(pPlugInfo->hContext, "Cellular_Interface_CellInfo_GetParamBoolValue",  Cellular_Interface_CellInfo_GetParamBoolValue);
 #endif
     g_pDslhDmlAgent                 = pPlugInfo->hDmlAgent;
     pGetParamValueByPathNameProc = (COSAGetParamValueByPathNameProc)pPlugInfo->AcquireFunction("COSAGetParamValueByPathName");

--- a/source/TR-181/middle_layer_src/cellularmgr_rbus_dml.c
+++ b/source/TR-181/middle_layer_src/cellularmgr_rbus_dml.c
@@ -70,6 +70,7 @@ extern extender_stats_t g_extender_stats;
 #define CELLULARMGR_ACCESSPOINT_TABLE            "Device.Cellular.AccessPoint."
 #define CELLULARMGR_UICC_TABLE                   "Device.Cellular.X_RDK_Uicc."
 #define PLMNACCESS_AVAILABLENETWORK_TABLE        "Device.Cellular.Interface.%d.X_RDK_PlmnAccess.AvailableNetworks."
+#define CELLULRMGR_INFACE_CELLINFO_TABLE         "Device.Cellular.Interface.%d.X_RDK_CellInfo."
 
 rbusError_t registerGeneratedDataElements(rbusHandle_t handle);
 
@@ -170,6 +171,16 @@ rbusError_t cellularmgr_Init()
                 }
             }
         }
+
+        snprintf(paramName, sizeof(paramName), CELLULRMGR_INFACE_CELLINFO_TABLE, (i + 1));
+
+        for(int n = 0; n < pstInterfaceInfo->ulCellInfoNoOfEntries; n++)
+        {
+            if (Sample_RegisterRow(paramName, (n+1), NULL, NULL) != RBUS_ERROR_SUCCESS)
+            {
+                CcspTraceError(("%s-%d: Failed to Add CellInfo Inst(%d) Table(%s) \n", __FUNCTION__, __LINE__, (n+1), paramName));
+            }
+        }
     }
 
     for(int k = 0; k < pstDmlCellular->ulAccessPointNoOfEntries; k++)
@@ -244,6 +255,16 @@ rbusError_t cellularmgr_Unload()
                 {
                     CcspTraceError(("%s-%d : Failed to Del AvailableNetworks Inst(%d) Table(%s) \n", __FUNCTION__, __LINE__, (m+1), paramName));
                 }
+            }
+        }
+
+        snprintf(paramName, sizeof(paramName), CELLULRMGR_INFACE_CELLINFO_TABLE, (i + 1));
+
+        for(int n = 0; n < pstInterfaceInfo->ulCellInfoNoOfEntries; n++)
+        {
+            if (Sample_UnregisterRow(paramName, (n+1)) != RBUS_ERROR_SUCCESS)
+            {
+                CcspTraceError(("%s-%d : Failed to Del CellInfo Inst(%d) Table(%s) \n", __FUNCTION__, __LINE__, (n+1), paramName));
             }
         }
 
@@ -3281,6 +3302,341 @@ rbusError_t Cellular_AccessPoint_SetParamStringValue_rbus(rbusHandle_t handle, r
     return RBUS_ERROR_SUCCESS;
 }
 
+// Cellular Interface intra and inter frequency cell information data models
+
+bool Cellular_Interface_CellInfo_IsUpdated_rbus(void* ctx)
+{
+    PCELLULARMGR_CELLULAR_DATA  pMyObject           = (PCELLULARMGR_CELLULAR_DATA) g_pBEManager->hCellular;
+    PCELLULAR_DML_INFO          pstDmlCellular      = NULL;
+    PCELLULAR_INTERFACE_INFO    pstInterfaceInfo    = NULL;
+    INT index = 0;
+
+    if (pMyObject == NULL) {
+        CcspTraceError(("%s-%d: invalid cellularmgr object\n", __FUNCTION__, __LINE__));
+        return false;
+    }
+
+    pstDmlCellular = (PCELLULAR_DML_INFO) pMyObject->pstDmlCellular;
+    if (pstDmlCellular == NULL)
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr dml\n", __FUNCTION__, __LINE__));
+        return false;
+    }
+
+    sscanf(((HandlerContext *)ctx)->fullName, "Device.Cellular.Interface.%d.X_RDK_CellInfo.", &index);
+    if ((pstDmlCellular->ulInterfaceNoEntries > 0) && index)
+    {
+        pstInterfaceInfo = &(pstDmlCellular->pstInterfaceInfo[index-1]);
+    }
+
+    if (pstInterfaceInfo == NULL)
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr interface: Inst (%d)\n", __FUNCTION__, __LINE__, index));
+        return false;
+    }
+
+    if ( ( AnscGetTickInSeconds() - pstInterfaceInfo->ulCellInfoListLastUpdatedTime ) < CELLULAR_INTERFACE_CELLINFO_LIST_REFRESH_THRESHOLD )
+    {
+        return false;
+    }
+    else
+    {
+        pstInterfaceInfo->ulCellInfoListLastUpdatedTime = AnscGetTickInSeconds();
+        CcspTraceError(("%s-%d: updated\n",__FUNCTION__, __LINE__));
+	    return true;
+    }
+    
+    return true;
+}
+
+rbusError_t Cellular_Interface_CellInfo_Synchronize_rbus(void* ctx)
+{
+    PCELLULARMGR_CELLULAR_DATA  pMyObject           = (PCELLULARMGR_CELLULAR_DATA) g_pBEManager->hCellular;
+    PCELLULAR_DML_INFO          pstDmlCellular      = NULL;
+    PCELLULAR_INTERFACE_INFO    pstInterfaceInfo    = NULL;
+    INT index = 0;
+
+    if (pMyObject == NULL) {
+        CcspTraceError(("%s-%d: invalid cellularmgr object\n", __FUNCTION__, __LINE__));
+        return false;
+    }
+
+    pstDmlCellular = (PCELLULAR_DML_INFO) pMyObject->pstDmlCellular;
+    if (pstDmlCellular == NULL)
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr dml\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    sscanf(((HandlerContext *)ctx)->fullName, "Device.Cellular.Interface.%d.X_RDK_CellInfo.", &index);
+    if ((pstDmlCellular->ulInterfaceNoEntries > 0) && index)
+    {
+        pstInterfaceInfo = &(pstDmlCellular->pstInterfaceInfo[index-1]);
+    }
+
+    if (pstInterfaceInfo == NULL)
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr interface: Inst (%d)\n", __FUNCTION__, __LINE__, index));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    char param_name[BUFLEN_256] = {0};
+    sprintf(param_name, CELLULRMGR_INFACE_CELLINFO_TABLE, index);
+    ULONG ulPrevNoOfEntries = pstInterfaceInfo->ulCellInfoNoOfEntries;
+
+    //Get available intra, inter frequency cell information
+    CELL_LOCATION_SUBINFO loc = CellularMgr_GetCellLocationSubsciptionStatus( );
+    CellularMgr_GetCellInformation(&pstInterfaceInfo->pstCellInfo, &pstInterfaceInfo->ulCellInfoNoOfEntries, loc);
+
+    /**
+     *  RBUS Limitation Hack:
+     *  We need to unregister all rows except default 1st row and set context
+     * */
+    if( ulPrevNoOfEntries > 0 )
+    {
+        for( int i = 1; i < ulPrevNoOfEntries; i++ )
+        {
+            if (Sample_UnregisterRow(param_name, (i+1)) == RBUS_ERROR_SUCCESS)
+            {
+                CcspTraceInfo(("%s: unregistered CellInfo table:Inst(%s%d) \n", __FUNCTION__, param_name, (i+1)));
+            }
+        }
+    }
+
+    if ( (pstInterfaceInfo->ulCellInfoNoOfEntries > 0) &&
+         (pstInterfaceInfo->pstCellInfo != NULL) )
+    {
+        for( int j = 0; j < pstInterfaceInfo->ulCellInfoNoOfEntries; j++ )
+        {
+            PCELLULAR_INTERFACE_CELL_INFO  *pstCellInfo = &(pstInterfaceInfo->pstCellInfo[j]);
+            if ( Sample_RegisterRow(param_name, (j+1), NULL, pstCellInfo) == RBUS_ERROR_SUCCESS )
+            {
+                CcspTraceInfo(("%s-%d: add CellInfo tableName(%s), Inst(%d) \n", __FUNCTION__, __LINE__, param_name, (j+1)));
+            } else {
+                SetRowContext(param_name, (j+1), NULL, pstCellInfo);
+                CcspTraceInfo(("%s-%d: set row context for tableName(%s), Inst(%d) \n",__FUNCTION__, __LINE__, param_name, (j+1)));
+            }
+        }
+    }
+    else if( pstInterfaceInfo->ulCellInfoNoOfEntries == 0 ) // RBUS Limitation: Fix
+    {
+        SetRowContext(param_name, 1, NULL, NULL);
+        pstInterfaceInfo->ulCellInfoNoOfEntries = 1;
+        CcspTraceInfo(("%s-%d: set row context for tableName(%s), Inst(%d) \n",__FUNCTION__, __LINE__, param_name, 1));
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+int do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(HandlerContext context)
+{ 
+    if( Cellular_Interface_CellInfo_IsUpdated_rbus(&context) )
+    {
+        return Cellular_Interface_CellInfo_Synchronize_rbus(&context);
+    }
+        
+    return 0;
+}
+
+static rbusError_t Cellular_Interface_CellInfo_GetEntryCount_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    HandlerContext context = GetPropertyContext(property);
+    rbusError_t ret;
+
+    if( ( ret = do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(context) ) != RBUS_ERROR_SUCCESS ) {
+        CcspTraceError(("%s-%d: cellinfo synchronize failed\n", __FUNCTION__, __LINE__));
+        return ret;
+    }
+
+    context = GetPropertyContext(property);
+    PCELLULAR_INTERFACE_INFO    pstInterfaceInfo = (PCELLULAR_INTERFACE_INFO)context.userData;
+
+    if ( pstInterfaceInfo == NULL )
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr interface instance\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    if( strncmp(context.name, "X_RDK_CellInfoNumberOfEntries", strlen("X_RDK_CellInfoNumberOfEntries")) == 0 )
+    {
+        rbusProperty_SetUInt64(property, pstInterfaceInfo->ulCellInfoNoOfEntries);
+    }
+    else
+    {
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+static rbusError_t Cellular_Interface_CellInfo_GetParamUlongValue_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    HandlerContext context = GetPropertyContext(property);
+    rbusError_t ret;
+
+    if( ( ret = do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(context) ) != RBUS_ERROR_SUCCESS ) {
+        CcspTraceError(("%s-%d: cellinfo synchronize failed\n", __FUNCTION__, __LINE__));
+        return ret;
+    }
+
+    context = GetPropertyContext(property);
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)context.userData;
+    if ( pstCellInfo == NULL )
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr cell info instance\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    if(strncmp(context.name, "MCC", strlen("MCC")) == 0)
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->MCC);
+    }
+    else if( strncmp(context.name, "MNC", strlen("MNC")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->MNC);
+    }
+    else if( strncmp(context.name, "TAC", strlen("TAC")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->TAC);
+    }
+    else if( strncmp(context.name, "GlobalCellId", strlen("GlobalCellId")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->GlobalCellId);
+    }
+    else if( strncmp(context.name, "TA", strlen("TA")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->TA);
+    }
+    else if( strncmp(context.name, "PhysicalCellId", strlen("PhysicalCellId")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->PhysicalCellId);
+    }
+    else if( strncmp(context.name, "RFCN", strlen("RFCN")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->RFCN);
+    }
+    else if( strncmp(context.name, "SectorId", strlen("SectorId")) == 0 )
+    {
+        rbusProperty_SetUInt32(property, pstCellInfo->SectorId);
+    }
+    else
+    {
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+static rbusError_t Cellular_Interface_CellInfo_GetParamStringValue_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    HandlerContext context = GetPropertyContext(property);
+    rbusError_t ret;
+
+    if( ( ret = do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(context) ) != RBUS_ERROR_SUCCESS ) {
+        CcspTraceError(("%s-%d: cellinfo synchronize failed\n", __FUNCTION__, __LINE__));
+        return ret;
+    }
+
+    context = GetPropertyContext(property);
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)context.userData;
+    if( pstCellInfo == NULL )
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr cell info instance\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    if( strncmp(context.name, "RAT", strlen("RAT")) == 0 )
+    {
+        rbusProperty_SetString(property, pstCellInfo->RAT);
+    }
+    else if( strncmp(context.name, "GPS", strlen("GPS")) == 0 )
+    {
+        rbusProperty_SetString(property, pstCellInfo->GPS);
+    }
+    else if( strncmp(context.name, "ScanType", strlen("ScanType")) == 0 )
+    {
+        rbusProperty_SetString(property, pstCellInfo->ScanType);
+    }
+    else if( strncmp(context.name, "OperatorName", strlen("OperatorName")) == 0 )
+    {
+        rbusProperty_SetString(property, pstCellInfo->OperatorName);
+    }
+    else
+    {
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+static rbusError_t Cellular_Interface_CellInfo_GetParamIntValue_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    HandlerContext context = GetPropertyContext(property);
+    rbusError_t ret;
+
+    if( ( ret = do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(context) ) != RBUS_ERROR_SUCCESS ) {
+        CcspTraceError(("%s-%d: cellinfo synchronize failed\n", __FUNCTION__, __LINE__));
+        return ret;
+    }
+
+    context = GetPropertyContext(property);
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)context.userData;
+    if( pstCellInfo == NULL )
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr cell info instance\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    if( strncmp(context.name, "RSSI", strlen("RSSI")) == 0 )
+    {
+        rbusProperty_SetInt32(property, pstCellInfo->RSSI);
+    }
+    else if( strncmp(context.name, "RSRP", strlen("RSRP")) == 0 )
+    {
+        rbusProperty_SetInt32(property, pstCellInfo->RSRP);
+    }
+    else if( strncmp(context.name, "RSRQ", strlen("RSRQ")) == 0 )
+    {
+        rbusProperty_SetInt32(property, pstCellInfo->RSRQ);
+    }
+    else
+    {
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
+static rbusError_t Cellular_Interface_CellInfo_GetParamBoolValue_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    HandlerContext context = GetPropertyContext(property);
+    rbusError_t ret;
+
+    if( ( ret = do_Cellular_Interface_CellInfo_IsUpdated_Cellular_Interface_CellInfo_Synchronize(context) ) != RBUS_ERROR_SUCCESS ) {
+        CcspTraceError(("%s-%d: cellinfo synchronize failed\n", __FUNCTION__, __LINE__));
+        return ret;
+    }
+
+    context = GetPropertyContext(property);
+    PCELLULAR_INTERFACE_CELL_INFO   pstCellInfo = (PCELLULAR_INTERFACE_CELL_INFO)context.userData;
+    if( pstCellInfo == NULL )
+    {
+        CcspTraceError(("%s-%d: invalid cellularmgr cell info instance\n", __FUNCTION__, __LINE__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    if( strncmp(context.name, "IsServing", strlen("IsServing")) == 0 )
+    {
+        rbusProperty_SetBoolean(property, pstCellInfo->IsServing);
+    }
+    else
+    {
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    return RBUS_ERROR_SUCCESS;
+}
+
 #ifdef RDK_SPEEDTEST_LTE
 static rbusError_t SpeedTest_GetParamBoolValue_rbus(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
 {
@@ -3357,7 +3713,7 @@ rbusError_t registerGeneratedDataElements(rbusHandle_t handle)
         {"Device.Cellular.CellularConfig", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_GetParamStringValue_rbus, Cellular_SetParamStringValue_rbus, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.X_RDK_DeviceManagement.Imei", RBUS_ELEMENT_TYPE_PROPERTY, {DeviceManagement_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.X_RDK_DeviceManagement.FactoryReset", RBUS_ELEMENT_TYPE_PROPERTY, {DeviceManagement_GetParamBoolValue_rbus, DeviceManagement_SetParamBoolValue_rbus, NULL, NULL, NULL, NULL}},
-	{"Device.Cellular.X_RDK_DeviceManagement.RebootDevice", RBUS_ELEMENT_TYPE_PROPERTY, {DeviceManagement_GetParamBoolValue_rbus, DeviceManagement_SetParamBoolValue_rbus, NULL, NULL, NULL, NULL}},
+	    {"Device.Cellular.X_RDK_DeviceManagement.RebootDevice", RBUS_ELEMENT_TYPE_PROPERTY, {DeviceManagement_GetParamBoolValue_rbus, DeviceManagement_SetParamBoolValue_rbus, NULL, NULL, NULL, NULL}},
 
         {"Device.Cellular.X_RDK_Firmware.CurrentImageVersion", RBUS_ELEMENT_TYPE_PROPERTY, {Firmware_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.X_RDK_Firmware.FallbackImageVersion", RBUS_ELEMENT_TYPE_PROPERTY, {Firmware_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
@@ -3407,7 +3763,7 @@ rbusError_t registerGeneratedDataElements(rbusHandle_t handle)
 
         {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworksNumberOfEntries", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetEntryCount_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.", RBUS_ELEMENT_TYPE_TABLE, {NULL, NULL, NULL, NULL, NULL, NULL}},
-	{"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.Mcc", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
+	    {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.Mcc", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.Mnc", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.Name", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetParamStringValue_rbus, NULL, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.Interface.{i}.X_RDK_PlmnAccess.AvailableNetworks.{i}.Allowed", RBUS_ELEMENT_TYPE_PROPERTY, {AvailableNetworks_GetParamBoolValue_rbus, NULL, NULL, NULL, NULL, NULL}},
@@ -3498,6 +3854,26 @@ rbusError_t registerGeneratedDataElements(rbusHandle_t handle)
         {"Device.Cellular.AccessPoint.{i}.Password", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_AccessPoint_GetParamStringValue_rbus, Cellular_AccessPoint_SetParamStringValue_rbus, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.AccessPoint.{i}.X_RDK_IpAddressFamily", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_AccessPoint_GetParamStringValue_rbus, Cellular_AccessPoint_SetParamStringValue_rbus, NULL, NULL, NULL, NULL}},
         {"Device.Cellular.AccessPoint.{i}.X_RDK_PdpInterfaceConfig", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_AccessPoint_GetParamStringValue_rbus, Cellular_AccessPoint_SetParamStringValue_rbus, NULL, NULL, NULL, NULL}},
+        
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfoNumberOfEntries", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetEntryCount_rbus, NULL, NULL, NULL, NULL, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.", RBUS_ELEMENT_TYPE_TABLE, {NULL, NULL, NULL, NULL, NULL, NULL}},
+        
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.MCC", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.MNC", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.TAC", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.GlobalCellId", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.RAT", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamStringValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.RSSI", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamIntValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.RSRP", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamIntValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.RSRQ", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamIntValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.TA", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.PhysicalCellId", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.RFCN", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.SectorId", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamUlongValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.IsServing", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamBoolValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.GPS", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamStringValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.ScanType", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamStringValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
+        {"Device.Cellular.Interface.{i}.X_RDK_CellInfo.{i}.OperatorName", RBUS_ELEMENT_TYPE_PROPERTY, {Cellular_Interface_CellInfo_GetParamStringValue_rbus, NULL, NULL, NULL, CellularMgrDmlSubscriptionHandler, NULL}},
 #ifdef RDK_SPEEDTEST_LTE
 	{"Device.Cellular.X_RDK_SpeedTest.Enable", RBUS_ELEMENT_TYPE_PROPERTY, {SpeedTest_GetParamBoolValue_rbus, SpeedTest_SetParamBoolValue_rbus, NULL, NULL, NULL, NULL}}
 #endif /* RDK_SPEEDTEST_LTE */

--- a/source/TR-181/middle_layer_src/cellularmgr_rbus_dml.h
+++ b/source/TR-181/middle_layer_src/cellularmgr_rbus_dml.h
@@ -45,6 +45,10 @@
 
 #include <rbus.h>
 
+#ifndef BUFLEN_256
+#define BUFLEN_256          (256)
+#endif
+
 rbusError_t cellularmgr_Init();
 rbusError_t cellularmgr_Unload();
 

--- a/source/TR-181/middle_layer_src/cellularmgr_rbus_events.c
+++ b/source/TR-181/middle_layer_src/cellularmgr_rbus_events.c
@@ -95,6 +95,9 @@ void* CellularMgr_RBUS_Events_Monitor_Thread( void *arg )
           
                 //Fetching latest cell location information from HAL
                 CellularMgr_CellLocationInfo(&pstInterfaceInfo, LOC_NO_SUB_HAL_VALUE);
+
+                //Fetching latest cell freq information from HAL
+                CellularMgr_GetCellInformation(&pstInterfaceInfo.pstCellInfo, &pstInterfaceInfo.ulCellInfoNoOfEntries, LOC_NO_SUB_HAL_VALUE);
         }
       
         if(count_polling == 30)
@@ -146,6 +149,167 @@ int CellularMgr_RBUS_Events_PublishLinkAvailableStatus( unsigned char bPrevLinkS
 
         CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
         CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_BOOLEAN);         
+    }
+
+    return RETURN_OK;
+}
+
+int CellularMgr_RBUS_Events_Publish_X_RDK_CellInfo(CellularCellInfo *pPrevCellInfo, int prevCellCnt, CellularCellInfo *pCurrentCellInfo, int currentCellCnt) 
+{
+    CcspTraceInfo(("%s-%d: Publish CellInfo: subscribed flag:%d \n",__FUNCTION__, __LINE__, gRBUSSubListSt.stCellLocation.CellInfoSubFlag))
+    if (gRBUSSubListSt.stCellLocation.CellInfoSubFlag)
+    {
+        if ( (pPrevCellInfo == NULL) || (pCurrentCellInfo == NULL) )
+        {
+            CcspTraceInfo(("%s-%d: Publish CellInfo failed\n", __FUNCTION__, __LINE__))
+            return RETURN_ERROR;
+        }
+
+        char acTmpPrevValue[128]   = {0},
+             acTmpCurValue[128]    = {0},
+             acTmpParamName[256]   = {0};
+        int loopCnt;
+        
+        if ( prevCellCnt >= currentCellCnt ) {
+            // mismatched cnt, publish only available elems
+            loopCnt = currentCellCnt;
+        } else {
+            // mismatched cnt, publish only available elems
+            loopCnt = prevCellCnt;
+        }
+
+        // loop through all cell info and publish changed fields
+        for ( int i = 0; i < loopCnt; i++ ) 
+        {
+            if ( pPrevCellInfo[i].MCC != pCurrentCellInfo[i].MCC ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].MCC);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].MCC);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_MCC, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].MNC != pCurrentCellInfo[i].MNC ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].MNC);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].MNC);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_MNC, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].TAC != pCurrentCellInfo[i].TAC ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].TAC);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].TAC);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_TAC, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].globalCellId != pCurrentCellInfo[i].globalCellId ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].globalCellId);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].globalCellId);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_GLOBAL_CELL_ID, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( strncmp(pPrevCellInfo[i].RAT, pCurrentCellInfo[i].RAT,strlen(pCurrentCellInfo[i].RAT)) != 0 ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].RAT);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].RAT);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_RAT, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_STRING);         
+            }
+            if ( pPrevCellInfo[i].RSSI != pCurrentCellInfo[i].RSSI ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].RSSI);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].RSSI);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_RSSI, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_INT32);         
+            }
+            if ( pPrevCellInfo[i].RSRP != pCurrentCellInfo[i].RSRP ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].RSRP);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].RSRP);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_RSRP, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_INT32);         
+            }
+            if ( pPrevCellInfo[i].RSRQ != pCurrentCellInfo[i].RSRQ ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].RSRQ);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].RSRQ);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_RSRQ, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_INT32);         
+            }
+            if ( pPrevCellInfo[i].TA != pCurrentCellInfo[i].TA ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].TA);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].TA);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_TA, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].physicalCellId != pCurrentCellInfo[i].physicalCellId ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].physicalCellId);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].physicalCellId);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_PHY_CELL_ID, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].RFCN != pCurrentCellInfo[i].RFCN ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].MCC);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].MCC);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_RFCN, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].sectorId != pCurrentCellInfo[i].sectorId ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].sectorId);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].sectorId);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_SECTOR_ID, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_UINT32);         
+            }
+            if ( pPrevCellInfo[i].isServing != pCurrentCellInfo[i].isServing ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].isServing);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].isServing);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_IS_SERVING, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_BOOLEAN);         
+            }
+            if ( strncmp(pPrevCellInfo[i].GPS, pCurrentCellInfo[i].GPS, strlen(pCurrentCellInfo[i].GPS)) != 0 ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].GPS);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].GPS);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_GPS, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_STRING);         
+            }
+            if ( strncmp(pPrevCellInfo[i].scanType, pCurrentCellInfo[i].scanType, strlen(pCurrentCellInfo[i].scanType)) != 0 ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].scanType);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].scanType);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_SCAN_TYPE, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_STRING);         
+            }
+             if ( strncmp(pPrevCellInfo[i].operatorName, pCurrentCellInfo[i].operatorName, strlen(pCurrentCellInfo[i].operatorName)) != 0 ) {
+                snprintf(acTmpPrevValue, sizeof(acTmpPrevValue), "%u", pPrevCellInfo[i].operatorName);
+                snprintf(acTmpCurValue, sizeof(acTmpCurValue), "%u", pCurrentCellInfo[i].operatorName);
+                snprintf(acTmpParamName, sizeof(acTmpParamName), CELLULRMGR_INFACE_CELLINFO_OPERATOR_NAME, 1, (i+1));
+
+                CcspTraceInfo(("%s-%d: Publish DM(%s) Prev(%s) Current(%s)\n",__FUNCTION__, __LINE__, acTmpParamName,acTmpPrevValue,acTmpCurValue));
+                CellularMgr_Rbus_String_EventPublish_OnValueChange(acTmpParamName, acTmpPrevValue, acTmpCurValue, RBUS_STRING);         
+            }
+        }
     }
 
     return RETURN_OK;
@@ -222,6 +386,11 @@ ANSC_STATUS CellularMgr_Rbus_String_EventPublish_OnValueChange(char *dm_event, v
         case RBUS_STRING:
             rbusValue_SetString(Value, (char*)dm_value);
             rbusValue_SetString(preValue, (char*)prev_dm_value);
+        break;
+
+        case RBUS_UINT32:
+            rbusValue_SetUInt32(Value, atoi(dm_value));
+            rbusValue_SetUInt32(preValue, atoi(prev_dm_value));
         break;
 
         default:
@@ -477,6 +646,7 @@ rbusError_t CellularMgrDmlPublishEventHandler(rbusHandle_t handle, rbusEventSubA
             CcspTraceInfo(("%s-%d : X_RDK_BandInfo UnSub(%d) \n", __FUNCTION__, __LINE__, gRBUSSubListSt.stCellLocation.BandInfoSubFlag));
         }
     }
+
     return RBUS_ERROR_SUCCESS;
 }
 
@@ -576,6 +746,22 @@ rbusError_t CellularMgrDmlSubscriptionHandler(rbusHandle_t handle, rbusEventSubA
             CcspTraceInfo(("%s-%d : UserResetCount UnSub(%d) \n", __FUNCTION__, __LINE__, g_extender_stats.UserResetCountFlag));
         }
     }
+    else if(strstr(eventName, ".X_RDK_CellInfo"))
+    {
+        *autoPublish = FALSE;
+        if (action == RBUS_EVENT_ACTION_SUBSCRIBE)
+        {
+            gRBUSSubListSt.stCellLocation.CellInfoSubFlag++;
+            CcspTraceInfo(("%s-%d : X_RDK_CellInfo Sub(%d) Interval(%d)\n", __FUNCTION__, __LINE__, gRBUSSubListSt.stCellLocation.CellInfoSubFlag, interval));
+        }
+        else
+        {
+            if (gRBUSSubListSt.stCellLocation.CellInfoSubFlag)
+                gRBUSSubListSt.stCellLocation.CellInfoSubFlag--;
+            CcspTraceInfo(("%s-%d : X_RDK_CellInfo UnSub(%d) \n", __FUNCTION__, __LINE__, gRBUSSubListSt.stCellLocation.CellInfoSubFlag));
+        }
+    }
+
     return RBUS_ERROR_SUCCESS;
 }
 

--- a/source/TR-181/middle_layer_src/cellularmgr_rbus_events.h
+++ b/source/TR-181/middle_layer_src/cellularmgr_rbus_events.h
@@ -61,6 +61,22 @@ extern "C" {
 #define CELLULARMGR_INFACE_STATUS                          "Device.Cellular.Interface.%d.Status"
 #define CELLULARMGR_INFACE_PHY_CONNECTION_STATUS           "Device.Cellular.Interface.%d.X_RDK_PhyConnectedStatus"
 #define CELLULARMGR_INFACE_LINK_AVAILABLE_STATUS           "Device.Cellular.Interface.%d.X_RDK_LinkAvailableStatus"
+#define CELLULRMGR_INFACE_CELLINFO_MCC                     "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.MCC"
+#define CELLULRMGR_INFACE_CELLINFO_MNC                     "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.MNC"
+#define CELLULRMGR_INFACE_CELLINFO_TAC                     "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.TAC"
+#define CELLULRMGR_INFACE_CELLINFO_GLOBAL_CELL_ID          "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.GlobalCellId"
+#define CELLULRMGR_INFACE_CELLINFO_RAT                     "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.RAT"
+#define CELLULRMGR_INFACE_CELLINFO_RSSI                    "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.RSSI"
+#define CELLULRMGR_INFACE_CELLINFO_RSRP                    "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.RSRP"
+#define CELLULRMGR_INFACE_CELLINFO_RSRQ                    "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.RSRQ"
+#define CELLULRMGR_INFACE_CELLINFO_TA                      "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.TA"
+#define CELLULRMGR_INFACE_CELLINFO_PHY_CELL_ID             "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.PhysicalCellId"
+#define CELLULRMGR_INFACE_CELLINFO_RFCN                    "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.RFCN"
+#define CELLULRMGR_INFACE_CELLINFO_SECTOR_ID               "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.SectorId"
+#define CELLULRMGR_INFACE_CELLINFO_IS_SERVING              "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.IsServing"
+#define CELLULRMGR_INFACE_CELLINFO_GPS                     "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.GPS"
+#define CELLULRMGR_INFACE_CELLINFO_SCAN_TYPE               "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.ScanType"
+#define CELLULRMGR_INFACE_CELLINFO_OPERATOR_NAME           "Device.Cellular.Interface.%d.X_RDK_CellInfo.%d.OperatorName"
 
 #define RBUS_DEVICE_MODE          "Device.X_RDKCENTRAL-COM_DeviceControl.DeviceNetworkingMode"
 
@@ -87,6 +103,7 @@ typedef struct
     uint GlobalCellIdSubFlag;
     uint ServingCellIdSubFlag;
     uint BandInfoSubFlag;
+    uint CellInfoSubFlag;
 
 }CellularMgr_rbusSubListForCellLocationSt;
 


### PR DESCRIPTION
Reason for change: Implemetation for user story RDKB-60682. Included changes to support rbus subscription.

Test Procedure: Unit tested by performing dmcli get operation for Cell Info table at different table, property levels. Restart of cellular manager component done and verified that there are no issues. Executed rbuscli in interactive mode and verified subscription works as expected. Added a HACK to test. HACK was to publish CellInfo parameters even when there is no change in values.

Risks: Implementation is specific to cellular manager cell information. If there is a failure in dmcli for any CellInfo table the, Device.Cellular. table's get might be affected.

Priority: P2 ('P0'>high , 'P1'>medium, 'P2'>low)