### PR TITLE
RDKB-61797: rbus subscribed event not having expected string value

### DIFF
--- a/source/CellularManager/cellular_hal_qmi_apis.c
+++ b/source/CellularManager/cellular_hal_qmi_apis.c
@@ -1172,7 +1172,7 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
         ( TRUE == qmi_device_is_open( gpstQMIContext->qmiDevice ) ) )
     {
         ContextNASInfo   *nasCtx = &(gpstQMIContext->nasCtx);
-        ContextWDSInfo   *wdsCtx = &(pstQMIContext->wdsCtx);
+        ContextWDSInfo   *wdsCtx = &(gpstQMIContext->wdsCtx);
 
 	if (NULL != wdsCtx && NULL != nasCtx)
 	{

--- a/source/CellularManager/cellular_hal_qmi_apis.c
+++ b/source/CellularManager/cellular_hal_qmi_apis.c
@@ -1193,7 +1193,12 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
                 int cnt = 0;
                 CellularCellInfo *pTmp_cell_info = NULL;
                 CellularCurrentPlmnInfoStruct *pstPlmnInfo = &(nasCtx->stPlmnInfo);
-                
+                char currRAT[256];
+                memset(currRAT, '\0', sizeof(currRAT));
+
+                // get current RAT from wdsCtx
+                (void)cellular_hal_qmi_get_current_radio_technology(currRAT);
+
                 pTmp_cell_info = (CellularCellInfo *) malloc( sizeof( CellularCellInfo ) * tmpTotalCellCnt );
                 if (pTmp_cell_info == NULL) {
                     CELLULAR_HAL_DBG_PRINT("%s-%d: failed to allocate memory for cell info copy\n", __FUNCTION__, __LINE__);
@@ -1214,16 +1219,11 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
                             pTmp_cell_info[cnt].TAC = nasCtx->trackingAreaCode;
                             pTmp_cell_info[cnt].TA = nasCtx->timingAdvance;
 
-			    char tmp_RAT[256];
-			    memset(tmp_RAT, '\0', sizeof(tmp_RAT));
-
-			    cellular_hal_qmi_get_current_radio_technology(tmp_RAT);
-			    CELLULAR_HAL_DBG_PRINT("%s-%d: NAGA-DEBUG: preferred=%s, current=%s\n", __FUNCTION__, __LINE__, nasCtx->preferredRAT, tmp_RAT);
-                            snprintf(pTmp_cell_info[cnt].RAT, sizeof(pTmp_cell_info[cnt].RAT), "%s", nasCtx->preferredRAT);
                             snprintf(pTmp_cell_info[cnt].operatorName, sizeof(pTmp_cell_info[cnt].operatorName), "%s", nasCtx->operator_name);
                             pTmp_cell_info[cnt].MCC = pstPlmnInfo->MCC;
                             pTmp_cell_info[cnt].MNC = pstPlmnInfo->MNC;
                         }
+                        snprintf(pTmp_cell_info[cnt].RAT, sizeof(pTmp_cell_info[cnt].RAT), "%s", currRAT);
                         pTmp_cell_info[cnt].physicalCellId = pCellInfo->physical_cell_id;
                         pTmp_cell_info[cnt].RSRQ = pCellInfo->rsrq;
                         pTmp_cell_info[cnt].RSRP = pCellInfo->rsrp;

--- a/source/CellularManager/cellular_hal_qmi_apis.c
+++ b/source/CellularManager/cellular_hal_qmi_apis.c
@@ -1172,6 +1172,12 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
         ( TRUE == qmi_device_is_open( gpstQMIContext->qmiDevice ) ) )
     {
         ContextNASInfo   *nasCtx = &(gpstQMIContext->nasCtx);
+        ContextWDSInfo   *wdsCtx = &(pstQMIContext->wdsCtx);
+
+	if (NULL != wdsCtx && NULL != nasCtx)
+	{
+	    CELLULAR_HAL_DBG_PRINT("%s-%d: NAGA DEBUG: preferredRAT=%s, currentRAT=%s\n", nasCtx->preferredRAT, wdsCtx->currentRAT); 
+	}
 
         if( NULL != nasCtx->nasClient )
         {

--- a/source/CellularManager/cellular_hal_qmi_apis.c
+++ b/source/CellularManager/cellular_hal_qmi_apis.c
@@ -1172,12 +1172,6 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
         ( TRUE == qmi_device_is_open( gpstQMIContext->qmiDevice ) ) )
     {
         ContextNASInfo   *nasCtx = &(gpstQMIContext->nasCtx);
-        ContextWDSInfo   *wdsCtx = &(gpstQMIContext->wdsCtx);
-
-	if (NULL != wdsCtx && NULL != nasCtx)
-	{
-	    CELLULAR_HAL_DBG_PRINT("%s-%d: NAGA DEBUG: preferredRAT=%s, currentRAT=%s\n", nasCtx->preferredRAT, wdsCtx->currentRAT); 
-	}
 
         if( NULL != nasCtx->nasClient )
         {
@@ -1219,6 +1213,12 @@ int cellular_hal_qmi_get_cell_information(CellularCellInfo *pCell_info, unsigned
                             pTmp_cell_info[cnt].globalCellId = nasCtx->globalCellId;
                             pTmp_cell_info[cnt].TAC = nasCtx->trackingAreaCode;
                             pTmp_cell_info[cnt].TA = nasCtx->timingAdvance;
+
+			    char tmp_RAT[256];
+			    memset(tmp_RAT, '\0', sizeof(tmp_RAT));
+
+			    cellular_hal_qmi_get_current_radio_technology(tmp_RAT);
+			    CELLULAR_HAL_DBG_PRINT("%s-%d: NAGA-DEBUG: preferred=%s, current=%s\n", __FUNCTION__, __LINE__, nasCtx->preferredRAT, tmp_RAT);
                             snprintf(pTmp_cell_info[cnt].RAT, sizeof(pTmp_cell_info[cnt].RAT), "%s", nasCtx->preferredRAT);
                             snprintf(pTmp_cell_info[cnt].operatorName, sizeof(pTmp_cell_info[cnt].operatorName), "%s", nasCtx->operator_name);
                             pTmp_cell_info[cnt].MCC = pstPlmnInfo->MCC;


### PR DESCRIPTION
RCA: Cell info RAT value is fetched from nasCtx preferred RAT
This is wrong. Actual RAT to be returned is the current RAT the
cell corresponds to. This is available in wdsCtx.

Fix: Fetching correct current RAT from wdsCtx and updated cell info

UT logs: 
[RDKB-61797_rat_ut_logs.txt](https://github.com/user-attachments/files/22548393/RDKB-61797_rat_ut_logs.txt)
