### PR TITLE
RDKB-65075: Fix native build failure

### DIFF
--- a/cov_docker_script/configure_options.conf
+++ b/cov_docker_script/configure_options.conf
@@ -24,6 +24,8 @@
 -I/usr/include/glib-2.0
 -I/usr/include/libqmi-glib
 
+# Safec dummy API
+-DSAFEC_DUMMY_API
 
 # Standard defines
 -DSC_POSIX_SEM


### PR DESCRIPTION
Reason for change: Native build for Coverity scan
Test Procedure: Native build should be success
Priority: P1
Risks: None
Signed-off-by: Netaji Panigrahi Netaji_Panigrahi@comcast.com